### PR TITLE
Include altname information during write_meme()

### DIFF
--- a/R/write_meme.R
+++ b/R/write_meme.R
@@ -98,7 +98,7 @@ write_meme <- function(motifs, file, version = 5, bkg, strand,
   .write_meme <- function(motifs) {
   
     motif <- motifs
-    lines_out <- paste("MOTIF", motif@name)
+    lines_out <- ifelse(motif@altname != "", paste("MOTIF", motif@name), paste("MOTIF", motif@altname))
     nsites <- motif@nsites
     nsites <- ifelse(length(nsites) == 0, 100, nsites)
     eval <- motif@eval

--- a/R/write_meme.R
+++ b/R/write_meme.R
@@ -96,9 +96,17 @@ write_meme <- function(motifs, file, version = 5, bkg, strand,
                  paste(bkg.2, bkg, collapse = " "), "")
 
   .write_meme <- function(motifs) {
-  
+
+    write_meme_name <- function(motif){
+      if (length(motif@altname) == 0){
+        return(paste("MOTIF", motif@name))
+      } else {
+        paste("MOTIF", motif@name, motif@altname)
+      }
+    }
+
     motif <- motifs
-    lines_out <- ifelse(motif@altname != "", paste("MOTIF", motif@name), paste("MOTIF", motif@altname))
+    lines_out <- write_meme_name(motif)
     nsites <- motif@nsites
     nsites <- ifelse(length(nsites) == 0, 100, nsites)
     eval <- motif@eval


### PR DESCRIPTION
The current implementation of `write_meme` does not include the `altname` if it is set. This change includes that information in the meme-format entry if it exists. 

I tested this by running:
```
# devtools::load_all(".")
m <- create_motif()
mm <- create_motif()

mm@altname <- "other name"

write_meme(m, "test_no_altname.meme")
write_meme(mm, "test_has_altname.meme")
# Manually inspect outputs
```

Change builds on my system, but I'm missing a couple dependencies to pass R CMD CHECK, so might want to test that also.