### PR TITLE
Fix summarise_motif dropping altname

### DIFF
--- a/src/universalmotif-class.cpp
+++ b/src/universalmotif-class.cpp
@@ -739,7 +739,7 @@ Rcpp::DataFrame summarise_motifs_cpp(const Rcpp::List &motifs) {
     name[i] = name_i[0];
 
     Rcpp::StringVector altname_i = mot.slot("altname");
-    altname[i] = altname.size() == 1 ? altname_i[0] : NA_STRING;
+    altname[i] = altname_i.size() == 1 ? altname_i[0] : NA_STRING;
 
     Rcpp::StringVector family_i = mot.slot("family");
     family[i] = family_i.size() == 1 ? family_i[0] : NA_STRING;

--- a/tests/testthat/test_utils.R
+++ b/tests/testthat/test_utils.R
@@ -17,12 +17,13 @@ test_that("summarise_motifs works", {
 
   m1 <- create_motif("GYNCHGCCKT", name = "motif-1", nsites = 212)
   m2 <- create_motif("GTYCTWYWAK", name = "motif-2", nsites = 147)
-  m3 <- create_motif("TAYTAAMCAA", name = "motif-3", nsites = 117)
+  m3 <- create_motif("TAYTAAMCAA", name = "motif-3", nsites = 117, altname = "alt_motif-3")
 
   res <- summarise_motifs(list(m1, m2, m3))
 
   expect_true(is.data.frame(res))
   expect_equal(res$name, c("motif-1", "motif-2", "motif-3"))
+  expect_equal(res$altname, c(NA, NA, "alt_motif-3"))
   expect_equal(res$consensus, c("GYNCHGCCKT", "GTYCTWYWAK", "TAYTAAMCAA"))
   expect_equal(res$alphabet, c("DNA", "DNA", "DNA"))
   expect_equal(res$strand, c("+-", "+-", "+-"))


### PR DESCRIPTION
Fixes #8. 

Fixed a typo in `summarise_motifs_cpp` which caused altname to be lost even when set. Added unit test to check that altname is correctly summarised. 