### PR TITLE
Holdout unsupported data types during update_motifs

### DIFF
--- a/R/universalmotif_df.R
+++ b/R/universalmotif_df.R
@@ -141,6 +141,7 @@ update_motifs <- function(motif_df, extrainfo = FALSE) {
   cols_new <- cols_new[cols_new != "motif"]
   cols_old <- colnames(old_df)
   cols_old <- cols_old[cols_old != "motif"]
+  extrainfo_holdout_cols <- NA_character_
   if (extrainfo) {
     # for now, just always update extrainfo...
     cols_extrainfo <- cols_new[!cols_new %in% cols_old]
@@ -216,10 +217,10 @@ update_motifs <- function(motif_df, extrainfo = FALSE) {
     }
   }
 
-  if (length(extrainfo_holdout_cols) > 0){
+  if (extrainfo & length(extrainfo_holdout_cols) > 0){
     # Add back any heldout info
     new_df <- to_df(m, extrainfo)
-    return(merge(new_df, extrainfo_holdouts, by = "name"))
+    return(merge(new_df, extrainfo_holdouts, by = "name", all.x = TRUE))
   } else {
     return(to_df(m, extrainfo))
   }

--- a/R/universalmotif_df.R
+++ b/R/universalmotif_df.R
@@ -216,7 +216,7 @@ update_motifs <- function(motif_df, extrainfo = FALSE) {
     }
   }
 
-  if (extrainfo & length(extrainfo_holdout_cols) > 0){
+  if (extrainfo & !is.na(extrainfo_holdout_cols)){
     # Add back any heldout info
     new_df <- to_df(m, extrainfo)
     return(merge(new_df, extrainfo_holdouts, by = "name", all.x = TRUE))
@@ -254,6 +254,7 @@ bkgs_are_different <- function(x, y) {
 }
 
 extrainfo_to_df <- function(x) {
+  # TODO: bug is around here where column name isn't correctly added??
   y <- lapply(x, vec_to_df_mot)
   cnames <- unique(unlist(lapply(y, colnames)))
   for (i in seq_along(y)) {

--- a/R/universalmotif_df.R
+++ b/R/universalmotif_df.R
@@ -146,7 +146,21 @@ update_motifs <- function(motif_df, extrainfo = FALSE) {
     cols_extrainfo <- cols_new[!cols_new %in% cols_old]
     cols_extrainfo <- cols_extrainfo[cols_extrainfo != "bkg"]
     if (length(cols_extrainfo)) {
+
       extrainfo_new <- updated_df[, cols_extrainfo, drop = FALSE]
+
+      # TOOD: hold out unsupported datatypes
+      # Current "supported" types are "character", "numeric" and "integer"
+      # Should logical be held out or not?
+      extrainfo_types <- vapply(extrainfo_new, class, character(1))
+      extrainfo_holdout_cols <- names(extrainfo_types[!(extrainfo_types %in% c("character", "numeric", "integer"))])
+      extrainfo_holdouts <- extrainfo_new[,extrainfo_holdout_cols]
+      # TODO: Consider a message for holdouts? I think it's unnecessary.
+      # TODO: check that this sort order is always correct?
+      extrainfo_holdouts$name <- updated_df$name
+      # Pass un-heldout extrainfo to motif
+      extrainfo_new <- extrainfo_new[,-which(names(extrainfo_new) %in% extrainfo_holdout_cols)]
+
       for (i in seq_along(m)) {
         m[[i]]["extrainfo"] <- clean_up_extrainfo_df(extrainfo_new[i, , drop = FALSE])
       }
@@ -201,7 +215,14 @@ update_motifs <- function(motif_df, extrainfo = FALSE) {
       }
     }
   }
-  to_df(m, extrainfo)
+
+  if (length(extrainfo_holdout_cols) > 0){
+    # Add back any heldout info
+    new_df <- to_df(m, extrainfo)
+    return(merge(new_df, extrainfo_holdouts, by = "name"))
+  } else {
+    return(to_df(m, extrainfo))
+  }
 }
 
 #' @export

--- a/R/universalmotif_df.R
+++ b/R/universalmotif_df.R
@@ -148,19 +148,18 @@ update_motifs <- function(motif_df, extrainfo = FALSE) {
     cols_extrainfo <- cols_extrainfo[cols_extrainfo != "bkg"]
     if (length(cols_extrainfo)) {
 
-      extrainfo_new <- updated_df[, cols_extrainfo, drop = FALSE]
+      # keep name here temporarily to ensure sort order is OK
+      extrainfo_new <- updated_df[, c("name", cols_extrainfo), drop = FALSE]
 
       # TOOD: hold out unsupported datatypes
       # Current "supported" types are "character", "numeric" and "integer"
       # Should logical be held out or not?
       extrainfo_types <- vapply(extrainfo_new, class, character(1))
       extrainfo_holdout_cols <- names(extrainfo_types[!(extrainfo_types %in% c("character", "numeric", "integer"))])
-      extrainfo_holdouts <- extrainfo_new[,extrainfo_holdout_cols]
+      extrainfo_holdouts <- extrainfo_new[,c("name", extrainfo_holdout_cols)]
       # TODO: Consider a message for holdouts? I think it's unnecessary.
-      # TODO: check that this sort order is always correct?
-      extrainfo_holdouts$name <- updated_df$name
-      # Pass un-heldout extrainfo to motif
-      extrainfo_new <- extrainfo_new[,-which(names(extrainfo_new) %in% extrainfo_holdout_cols)]
+      # Pass un-heldout extrainfo to motif, & drop name column
+      extrainfo_new <- extrainfo_new[,-which(names(extrainfo_new) %in% c("name", extrainfo_holdout_cols)), drop = FALSE]
 
       for (i in seq_along(m)) {
         m[[i]]["extrainfo"] <- clean_up_extrainfo_df(extrainfo_new[i, , drop = FALSE])

--- a/R/universalmotif_df.R
+++ b/R/universalmotif_df.R
@@ -216,7 +216,7 @@ update_motifs <- function(motif_df, extrainfo = FALSE) {
       }
     }
   }
-  if (extrainfo & !is.na(extrainfo_holdout_cols)){
+  if (extrainfo & all(!is.na(extrainfo_holdout_cols))){
     # Add back any heldout info
     new_df <- to_df(m, extrainfo)
     # TODO: update id_cols strategy

--- a/tests/testthat/test_universalmotif_df.R
+++ b/tests/testthat/test_universalmotif_df.R
@@ -28,4 +28,16 @@ test_that("extrainfo gets moved around correctly", {
   expect_warning(requires_update(mydf2))
   expect_false(suppressWarnings(requires_update(mydf2)))
   expect_true(requires_update(mydf2, TRUE))
+
+  mydf3 <- mydf2
+  mydf3$list_column <- list("hello" = "darkness",
+                            "my old" = 0x667269656e64
+                            )
+  mydf3$factor_column <- as.factor(c("a", "b", "c"))
+  mydf3$char_column <- c("a", "b", "c")
+
+  mydf3_update <- update_motifs(mydf3, extrainfo = TRUE)
+  expect_equal(mydf3$list_column, mydf3_update$list_column)
+  expect_equal(mydf3$factor_column, mydf3_update$factor_column)
+  expect_equal(mydf3$char_column, mydf3_update$char_column)
 })

--- a/tests/testthat/test_universalmotif_df.R
+++ b/tests/testthat/test_universalmotif_df.R
@@ -29,15 +29,17 @@ test_that("extrainfo gets moved around correctly", {
   expect_false(suppressWarnings(requires_update(mydf2)))
   expect_true(requires_update(mydf2, TRUE))
 
-  mydf3 <- mydf2
-  mydf3$list_column <- list("hello" = "darkness",
-                            "my old" = 0x667269656e64
-                            )
-  mydf3$factor_column <- as.factor(c("a", "b", "c"))
-  mydf3$char_column <- c("a", "b", "c")
+  # Check that holdout works
+  # character isn't heldout, but factor & list should be
+  mydf3 <- update_motifs(mydf2, extrainfo = FALSE)
+  
+  mydf3$list_column <- list("hello" = "darkness", "my old" = 0x667269656e64)
+  mydf3$factor_column <- as.factor(letters[1:nrow(mydf3)])
+  mydf3$char_column <- letters[1:nrow(mydf3)]
 
   mydf3_update <- update_motifs(mydf3, extrainfo = TRUE)
   expect_equal(mydf3$list_column, mydf3_update$list_column)
   expect_equal(mydf3$factor_column, mydf3_update$factor_column)
   expect_equal(mydf3$char_column, mydf3_update$char_column)
 })
+


### PR DESCRIPTION
This change addresses issues discussed in #13 (https://github.com/bjmt/universalmotif/issues/13#issuecomment-803366926) related to how complex metadata are stored in `extrainfo`. This solution ignores all data types that are not `character`, `integer`, or `numeric` when calling `update_motifs` in order to prevent munging the data stored in those columns. They are then joined back to the updated `motif_df` currently by merging on `name` and `consensus`. Moving forward this should probably be made into a more unique identifier. Maybe just the row number of the input data.frame, but I wasn't 100% certain sort order would be preserved in all cases. If so, that's an easy swap (see the `id_cols` variable).

I also added a few unit tests to ensure these behave properly.

NOTE: this PR includes code from #18 fixing the `einfo` bug when only 1 extrainfo column exists. I kinda borked the git history here, so figured I'd just submit the dup.