### PR TITLE
run_meme alph parameters

### DIFF
--- a/R/run_meme.R
+++ b/R/run_meme.R
@@ -250,7 +250,7 @@ run_meme <- function(target.sequences, output = NULL,
                        stop("for custom alphabets, please pass an alphabet file",
                             " to 'alph'\n",
                             "  (http://meme-suite.org/doc/alphabet-format.html)"))
-  } else alph.arg <- "-file"
+  } else alph.arg <- alph
 
   if (is.null(names(target.sequences)))
     names(target.sequences) <- as.character(seq_len(length(target.sequences)))


### PR DESCRIPTION
In the original code, when alph is not null, it gets value of "-file". This will leads to the final execution line becomes "Running /software/MEME/bin/meme dummy.fasta -oc \
  test -file -shuf 2 -objfun classic -mod oops -minw 8 -maxw 50 -wg 11 -ws 1 -markov_order 0 -maxiter 50 \
  -distance 0.001 -brief 1000 -shuf 2 -csites 1000 -nmotifs 3 -seed 0 -wnsites 0.8". The MEME will throw an error as it can't recognize parameter "-file"